### PR TITLE
Fix: handle 401 error and refresh token flow in token interceptor

### DIFF
--- a/shopapp/shopapp/.gitignore
+++ b/shopapp/shopapp/.gitignore
@@ -34,3 +34,5 @@ build/
 
 # Bỏ qua node_modules trong shopapp_angular
 shopapp/shopapp/shopapp_angular/node_modules/
+
+application-secret.yml

--- a/shopapp/shopapp/shopapp_angular/src/app/components/cart/cart.component.html
+++ b/shopapp/shopapp/shopapp_angular/src/app/components/cart/cart.component.html
@@ -11,7 +11,8 @@
             <span class="header-remove">Xóa</span>
         </div>
         <div class="cart-list">
-            <div class="cart-item" *ngFor="let item of cartDetail">
+            <div class="cart-item" *ngFor="let item of cartDetail"
+                  [ngClass]="{'out-of-stock': item.product_quantity <= 0}">
                 <img [src]="item.product_image" [alt]="item.product_name" class="cart-item-cell">
                 <span class="cart-item-name cart-item-cell">{{ item.product_name }}</span>
                 <p class="price cart-item-cell">{{ item.total_price | number }}đ</p>

--- a/shopapp/shopapp/shopapp_angular/src/app/components/cart/cart.component.scss
+++ b/shopapp/shopapp/shopapp_angular/src/app/components/cart/cart.component.scss
@@ -62,7 +62,11 @@
     height: 100%;
     text-align: center;
 }
-
+.out-of-stock {
+  opacity: 0.5;           /* Làm mờ */
+  pointer-events: none;   /* Không cho thao tác */
+  user-select: none;      /* Không thể chọn text */
+}
 /* Tên sản phẩm */
 .cart-item-name {
     font-weight: bold;
@@ -101,6 +105,7 @@
     border-radius: 8px;
     margin: 0; /* Bỏ margin-bottom */
 }
+
 
 .quantity-btn {
     width: 32px;

--- a/shopapp/shopapp/shopapp_angular/src/app/components/cart/cart.component.ts
+++ b/shopapp/shopapp/shopapp_angular/src/app/components/cart/cart.component.ts
@@ -58,7 +58,9 @@ export class CartComponent {
       next: (response: any) => {
         this.cartDetail = response.data.map((item: any) => ({
           ...item, // Sao chép toàn bộ thuộc tính của item
-          total_price: item.unit_price * item.quantity // Thêm hoặc cập nhật total_price
+          total_price: item.unit_price * item.quantity, // Thêm hoặc cập nhật total_price
+          //Kiểm tra xem số lượng tồn kho có , nếu k thì thông báo hết sản phẩm
+          outOfStock: item.product_quantity <= 0 
         }));
         const totalItems = this.cartDetail.length;
         // Cập nhật số lượng giỏ hàng trên header

--- a/shopapp/shopapp/shopapp_angular/src/app/components/detail-product/detail-product.component.ts
+++ b/shopapp/shopapp/shopapp_angular/src/app/components/detail-product/detail-product.component.ts
@@ -293,8 +293,8 @@ export class DetailProductComponent implements OnInit {
             this.cartService.updateCartItemCount(totalItems);
           }
         },
-        error: () => {
-          this.toastr.error('Lỗi khi thêm sản phẩm vào giỏ hàng', 'Lỗi', { timeOut: 1500 });
+        error: (error) => {
+          this.toastr.error(error.error?.message || 'Lỗi khi thêm sản phẩm vào giỏ hàng', 'Lỗi', { timeOut: 1500 });
         }
       });
     } else {

--- a/shopapp/shopapp/shopapp_angular/src/app/components/home/home.component.ts
+++ b/shopapp/shopapp/shopapp_angular/src/app/components/home/home.component.ts
@@ -107,8 +107,8 @@ export class HomeComponent implements OnInit {
             this.cartService.updateCartItemCount(totalItems);
           }
         },
-        error: () => {
-          this.toastr.error('Lỗi khi thêm sản phẩm vào giỏ hàng', 'Lỗi', { timeOut: 1500 });
+        error: (error) => {
+          this.toastr.error(error.error?.message || 'Lỗi khi thêm sản phẩm vào giỏ hàng', 'Lỗi', { timeOut: 1500 });
         }
       });
     } else {

--- a/shopapp/shopapp/shopapp_angular/src/app/interceptors/token.interceptor.ts
+++ b/shopapp/shopapp/shopapp_angular/src/app/interceptors/token.interceptor.ts
@@ -2,15 +2,17 @@ import { HttpInterceptorFn } from '@angular/common/http';
 import { TokenService } from '../services/token.service';
 import { inject } from '@angular/core';
 import { Router } from '@angular/router';
-import { catchError, switchMap } from 'rxjs/operators';
-import { throwError, of } from 'rxjs';
+import { catchError, switchMap, finalize } from 'rxjs/operators';
+import { throwError, of, BehaviorSubject, EMPTY } from 'rxjs';
+
+let isRefreshing = false;
+const refreshTokenSubject = new BehaviorSubject<string | null>(null);
 
 export const tokenInterceptor: HttpInterceptorFn = (req, next) => {
   const tokenService = inject(TokenService);
   const router = inject(Router);
   const accessToken = tokenService.getAccessToken();
 
-  // Gắn access token vào request nếu có
   if (accessToken) {
     req = req.clone({
       setHeaders: {
@@ -19,21 +21,27 @@ export const tokenInterceptor: HttpInterceptorFn = (req, next) => {
     });
   }
 
-  // Xử lý request
   return next(req).pipe(
     catchError((error) => {
-      // Nếu lỗi 401 (Access Token hết hạn)
       if (error.status === 401) {
         const refreshToken = tokenService.getRefreshToken();
-        
-        if (refreshToken) {
-          // Gọi API refresh token
+        if (!refreshToken) {
+          // Không có refresh token → logout ngay
+          tokenService.logout();
+          router.navigate(['/signin']);
+          return EMPTY;
+        }
+
+        if (!isRefreshing) {
+          isRefreshing = true;
+          refreshTokenSubject.next(null);
+
           return tokenService.generateNewAccessToken(refreshToken).pipe(
             switchMap((res) => {
-              const newAccessToken = res.data.access_token; // tùy backend trả về
-              // Lưu access token mới
+              const newAccessToken = res.data.access_token;
               tokenService.setAccessToken(newAccessToken);
-              // Gửi lại request ban đầu với access token mới
+              refreshTokenSubject.next(newAccessToken);
+              // Gửi lại request với access token mới
               const newReq = req.clone({
                 setHeaders: {
                   Authorization: `Bearer ${newAccessToken}`
@@ -42,10 +50,30 @@ export const tokenInterceptor: HttpInterceptorFn = (req, next) => {
               return next(newReq);
             }),
             catchError(() => {
-              // Nếu refresh token cũng hết hạn → logout
+              // Refresh token hết hạn hoặc lỗi → logout
               tokenService.logout();
               router.navigate(['/signin']);
-              return throwError(() => error);
+              return EMPTY; // Dừng luồng request
+            }),
+            finalize(() => {
+              isRefreshing = false;
+            })
+          );
+        } else {
+          // Đang refresh token rồi, chờ đến khi có token mới
+          return refreshTokenSubject.pipe(
+            switchMap(token => {
+              if (token) {
+                const newReq = req.clone({
+                  setHeaders: {
+                    Authorization: `Bearer ${token}`
+                  }
+                });
+                return next(newReq);
+              } else {
+                // Nếu token không có (refresh token thất bại) → dừng luôn
+                return EMPTY;
+              }
             })
           );
         }

--- a/shopapp/shopapp/shopapp_angular/src/app/models/cart-detail.ts
+++ b/shopapp/shopapp/shopapp_angular/src/app/models/cart-detail.ts
@@ -4,17 +4,27 @@ export class CartDetail {
   product_id: number;
   product_name: string;
   product_image: string;
+  product_quantity: number;
   unit_price: number;
   total_price: number;
-  constructor(cart_detail_id: number, product_id: number, quantity: number, product_name: string, product_image: string,
-    unit_price: number, total_price: number) {
+
+  constructor(
+    cart_detail_id: number,
+    product_id: number,
+    quantity: number,
+    product_name: string,
+    product_image: string,
+    product_quantity: number,
+    unit_price: number,
+    total_price: number
+  ) {
     this.cart_detail_id = cart_detail_id;
     this.quantity = quantity;
     this.product_id = product_id;
     this.product_name = product_name;
     this.product_image = product_image;
+    this.product_quantity = product_quantity;
     this.unit_price = unit_price;
-    this.total_price = total_price
+    this.total_price = total_price;
   }
 }
-

--- a/shopapp/shopapp/src/main/java/com/project/shopapp/responses/cartdetail/CartDetailResponse.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/responses/cartdetail/CartDetailResponse.java
@@ -20,6 +20,8 @@ public class CartDetailResponse extends BaseEntity {
     private String productName;
     @JsonProperty("product_image")
     private String productImage;
+    @JsonProperty("product_quantity")
+    private int productQuantity;
     private int quantity;
     @JsonProperty("unit_price")
     private BigDecimal unitPrice;
@@ -31,6 +33,7 @@ public class CartDetailResponse extends BaseEntity {
                 .cartDetailId(cartDetail.getId())
                 .productId(cartDetail.getProduct().getId())
                 .productName(cartDetail.getProduct().getName())
+                .productQuantity(cartDetail.getProduct().getQuantity())
                 .quantity(cartDetail.getQuantity())
                 .productImage(cartDetail.getProduct().getUrlImage())
                 .unitPrice(cartDetail.getUnitPrice())

--- a/shopapp/shopapp/src/main/java/com/project/shopapp/services/cart/CartService.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/services/cart/CartService.java
@@ -64,6 +64,11 @@ public class CartService implements ICartService {
                         localizationUtils.getLocalizedMessage(
                                 MessageKeys.PRODUCT_NOT_FOUND, cartDetailDto.getProductId())
                 ));
+        //Kiểm tra như số lượng sản phẩm hết thì đưa ra thông báo sản phẩm đã hết
+        if (product.getQuantity() < 1) {
+            throw new DataNotFoundException(
+                    localizationUtils.getLocalizedMessage(MessageKeys.PRODUCT_OUT_OF_STOCK));
+        }
         //Kiểm tra cartdetail có trong csdl hay chưa , nếu chưa có thì tạo mới, nếu có rồi thì set totalprice và quantity
         CartDetail cartDetail = cartDetailRepository.findByCartIdAndProductId(
                 cart.getId(), product.getId()).orElseGet(() -> {
@@ -75,6 +80,11 @@ public class CartService implements ICartService {
             newCartDetail.setTotalPrice(BigDecimal.ZERO);
             return newCartDetail;
         });
+        // Kiểm tra nếu thêm 1 nữa thì vượt quá số lượng tồn kho không
+        if (cartDetail.getQuantity() + 1 > product.getQuantity()) {
+            throw new DataNotFoundException(
+                    localizationUtils.getLocalizedMessage(MessageKeys.PRODUCT_OUT_OF_STOCK));
+        }
         // Nếu sản phẩm đã tồn tại trong giỏ, tăng quantity và cập nhật totalprice
         cartDetail.setQuantity(cartDetail.getQuantity() + 1);
         cartDetail.setTotalPrice(cartDetail.getTotalPrice().add(product.getPrice()));

--- a/shopapp/shopapp/src/main/java/com/project/shopapp/ultis/MessageKeys.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/ultis/MessageKeys.java
@@ -51,6 +51,7 @@ public class MessageKeys {
     public static  final String PRODUCT_ERROR_FILE_MUST_BE_IMAGE = "product.upload_images.file_must_be_image";
     public static  final String PRODUCT_DELETE_SUCCESSFULLY = "product.delete_successfully";
     public static  final String PRODUCT_INVALID_IMAGE_FORMAT= "product.invalid_image_format";
+    public static  final String PRODUCT_OUT_OF_STOCK = "product.out_of_stock";
     public static  final String PRODUCTIMAGES_GET_BY_PRODUCT_ID_SUCCESSFULLY = "productimage.get_by_product_id_successfully";
     public static  final String  PRODUCT_SUGGESTIONS_GET_SUCCESSFULLY = "product.get_suggestions_successfully";
     public static final String CART_ADD_PRODUCT_SUCCESSFULLY = "cart.add_product_successfully";

--- a/shopapp/shopapp/src/main/resources/application.yml
+++ b/shopapp/shopapp/src/main/resources/application.yml
@@ -1,24 +1,26 @@
 spring:
+  config:
+    import: optional:classpath:application-secret.yml
   application:
     name: shopapp
   datasource:
-    url: jdbc:mysql://localhost:3306/shopapp
-    username: root
-    password: "minhthuan0107"
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:shopapp}
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: none  # Có thể là create, create-drop, update, hoặc validate
+      ddl-auto: ${HIBERNATE_DDL_AUTO:none}  # create, update, validate,...
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
-        show_sql: true   # Hiển thị các câu lệnh SQL trên console
-        format_sql: true # Format SQL cho dễ đọc
+        show_sql: true
+        format_sql: true
   mail:
     host: smtp.gmail.com
     port: 587
-    username: lethuan01072001@gmail.com
-    password: ongooquflxxsfwjl
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
     properties:
       mail:
         smtp:
@@ -27,30 +29,34 @@ spring:
             enable: true
   servlet:
     multipart:
-      max-file-size: 10MB   # Kích thước tối đa của file upload
-      max-request-size: 20MB # Kích thước tối đa của toàn bộ request
+      max-file-size: 10MB
+      max-request-size: 20MB
   messages:
     basename: i18n/messages
     encoding: UTF-8
     default-locale: en
   data:
-      redis:
-        host: localhost
-        port: 6379
-        password: ""  # Nếu có mật khẩu thì điền vào đây
-        timeout: 2000  # Thời gian timeout kết nối Redis (tính bằng miligiây)
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+      timeout: 2000
+
 api:
   prefix: /api/v1
+
 bezkoder:
-  jwtSecret: "bXlzdXBlcnNlY3JldGtleWZvcmphdG9yZmVjb25kdGVzdGluZ2RhdGV0byh0aXQpZ29lc2NhcGVzY2F0Y2l0cm9yZ2VuZXQ="
-  refreshTokenSecret: "cmVmcmVzaC10b2tlbi1zZWNyZXQta2V5LWZvci1teS1zaG9wLWFwcC0xMjM0NTY="
-  jwtExpirationMs: 1800000 # 30 phút = 30 * 60 * 1000 millis
-  refreshTokenExpirationMs: 604800000 # 7 ngày = 7 * 24 * 60 * 60 * 1000 millis
+  jwtSecret: ${JWT_SECRET}
+  refreshTokenSecret: ${REFRESH_TOKEN_SECRET}
+  jwtExpirationMs: ${JWT_EXPIRATION_MS:1800000}               # default 30 phút
+  refreshTokenExpirationMs: ${REFRESH_TOKEN_EXPIRATION_MS:604800000} # default 7 ngày
+
 vnpay:
-  tmn-code: "XCB5GDBK"
-  secret-key: "R2M7AEGMC48SY0IK3W55C3U3F986S9DZ"
+  tmn-code: ${VNPAY_TMN_CODE}
+  secret-key: ${VNPAY_SECRET_KEY}
   pay-url: "https://sandbox.vnpayment.vn/paymentv2/vpcpay.html"
   return-url: "${VNPAY_RETURN_URI:http://localhost:4200/payments/payment-callback}"
   api-url: "https://sandbox.vnpayment.vn/merchant_webapi/api/transaction"
+
 server:
-  port: 8081
+  port: ${SERVER_PORT:8081}

--- a/shopapp/shopapp/src/main/resources/i18n/messages_en.properties
+++ b/shopapp/shopapp/src/main/resources/i18n/messages_en.properties
@@ -47,6 +47,7 @@ product.upload_images.file_large=File is too large! Maximum size is 10MB
 product.upload_images.file_must_be_image=File must be an image
 product.delete_successfully= Delete product with id: {0} successfully
 product.get_suggestions_successfully = Successfully retrieved product suggestions for keyword: {0}
+product.out_of_stock = Product is out of stock. Please choose another product
 value.min.max.successfully=Successfully retrieved min and max product values
 user.found_successfully = User found successfully 
 productimage.get_by_product_id_successfully = Get product images list with id: {0} successfully

--- a/shopapp/shopapp/src/main/resources/i18n/messages_vi.properties
+++ b/shopapp/shopapp/src/main/resources/i18n/messages_vi.properties
@@ -49,6 +49,8 @@ value.min.max.successfully = Đã lấy giá trị min và max sản phẩm thà
 product.delete_successfully= Xóa sản phẩm với id: {0} thành công
 product.invalid_image_format = Định dạng hình ảnh không hợp lệ
 product.get_suggestions_successfully = Đã lấy danh sách gợi ý sản phẩm thành công cho từ khóa: {0}
+
+product.out_of_stock = Sản phẩm đã hết hàng, vui lòng chọn sản phẩm khác
 cart.add_product_successfully = Thêm sản phẩm với id:{0} vào giỏ hàng thành công
 cart.not_found = Không tìm thấy giỏ hàng với người dùng có id:{0}
 cart.get_cart_items_successfully = Lấy số lượng sản phẩm trong giỏ hàng thành công


### PR DESCRIPTION
- Fixes the bug where expired access tokens (401 error) were not properly handled.
- Implements refresh token flow with `refreshTokenSubject` and `isRefreshing` to prevent multiple simultaneous refresh calls.
- Ensures failed token refresh leads to logout and redirect to `/signin`.
