### PR TITLE
feat: implement create and soft delete logic for brand and related products

### DIFF
--- a/shopapp/shopapp/src/main/java/com/project/shopapp/controllers/admin/AdminBrandController.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/controllers/admin/AdminBrandController.java
@@ -1,0 +1,74 @@
+package com.project.shopapp.controllers.admin;
+
+import com.project.shopapp.components.LocalizationUtils;
+import com.project.shopapp.dtos.customer.brand.BrandDto;
+import com.project.shopapp.models.Brand;
+import com.project.shopapp.responses.ResponseObject;
+import com.project.shopapp.services.admin.brand.BrandAdminService;
+import com.project.shopapp.ultis.MessageKeys;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("${api.admin-prefix}/brands")
+public class AdminBrandController {
+    @Autowired
+    private LocalizationUtils localizationUtils;
+    @Autowired
+    private BrandAdminService brandAdminService;
+    @PostMapping("create")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ResponseObject> createBrand(@RequestBody @Valid BrandDto brandDto,
+                                                      BindingResult result) {
+        if (result.hasErrors()) {
+            List<String> errorMessages = result.getFieldErrors()
+                    .stream()
+                    .map(FieldError::getDefaultMessage)
+                    .toList();
+            return ResponseEntity.badRequest().body(ResponseObject.builder()
+                    .status(HttpStatus.BAD_REQUEST)
+                    .message(errorMessages.toString())
+                    .build());
+        }
+        try {
+            Brand brand = brandAdminService.createBrand(brandDto);
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(ResponseObject.builder()
+                            .status(HttpStatus.CREATED)
+                            .data(brand)
+                            .message(localizationUtils.getLocalizedMessage(
+                                    MessageKeys.BRAND_CREATED_SUCCESSFULLY, brand.getId()))
+                            .build());
+        } catch (Exception e){
+            return ResponseEntity.badRequest().body(ResponseObject.builder()
+                    .status(HttpStatus.BAD_REQUEST)
+                    .message(e.getMessage())
+                    .build());
+        }
+    }
+    @DeleteMapping("delete/{brandId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ResponseObject> deleteBrandById(@Valid @PathVariable("brandId") long brandId) {
+        try {
+            brandAdminService.deleteBrandById(brandId);
+            return ResponseEntity.ok(ResponseObject.builder()
+                    .status(HttpStatus.OK)
+                    .message(localizationUtils.getLocalizedMessage(
+                            MessageKeys.BRAND_DELETE_SUCCESSFULLY, brandId))
+                    .build());
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(ResponseObject.builder()
+                    .status(HttpStatus.BAD_REQUEST)
+                    .message(e.getMessage())
+                    .build());
+        }
+    }
+}

--- a/shopapp/shopapp/src/main/java/com/project/shopapp/controllers/user/BrandController.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/controllers/user/BrandController.java
@@ -25,30 +25,7 @@ public class BrandController {
     private final LocalizationUtils localizationUtils;
     private final BrandService brandService;
 
-    @PostMapping("")
-    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
-    public ResponseEntity<ResponseObject> createBrand(@RequestBody @Valid BrandDto brandDto,
-                                                      BindingResult result) {
-        if (result.hasErrors()) {
-            List<String> errorMessages = result.getFieldErrors()
-                    .stream()
-                    .map(FieldError::getDefaultMessage)
-                    .toList();
-            return ResponseEntity.badRequest().body(ResponseObject.builder()
-                    .status(HttpStatus.BAD_REQUEST)
-                    .message(errorMessages.toString())
-                    .build());
-        }
-        Brand brand = brandService.createBrand(brandDto);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ResponseObject.builder()
-                        .status(HttpStatus.CREATED)
-                        .data(brand)
-                        .message(localizationUtils.getLocalizedMessage(
-                                MessageKeys.BRAND_CREATED_SUCCESSFULLY, brand.getId()))
-                        .build());
 
-    }
 
     @GetMapping("/get-all")
     public ResponseEntity<ResponseObject> getAllBrands() {

--- a/shopapp/shopapp/src/main/java/com/project/shopapp/models/Brand.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/models/Brand.java
@@ -16,4 +16,6 @@ public class Brand extends BaseEntity{
     private Long id;
     @Column(name = "name", nullable = false)
     private String name;
+    @Column(name = "is_deleted")
+    private boolean isDeleted = false;
 }

--- a/shopapp/shopapp/src/main/java/com/project/shopapp/repositories/BrandRepository.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/repositories/BrandRepository.java
@@ -1,15 +1,33 @@
 package com.project.shopapp.repositories;
 
 import com.project.shopapp.models.Brand;
+import com.project.shopapp.models.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BrandRepository extends JpaRepository<Brand,Long> {
-    @Query(value = "SELECT DISTINCT b.* FROM brands b JOIN products p ON b.id = p.brand_id WHERE p.category_id = :categoryId", nativeQuery = true)
+    List<Brand> findByIsDeletedFalse();
+
+    Optional<Brand> findByIdAndIsDeletedFalse(Long brandId);
+    //Lấy thương hiệu của những sản phẩm thuộc danh mục
+    @Query(value = "SELECT DISTINCT b.* FROM brands b " +
+            "JOIN products p ON b.id = p.brand_id " +
+            "WHERE p.category_id = :categoryId AND b.is_deleted = false ", nativeQuery = true)
     List<Brand> findDistinctByCategory(@Param("categoryId") Long categoryId);
+
+    @Query(value = "SELECT * FROM brands " +
+            "WHERE REPLACE(LOWER(name), ' ', '') = REPLACE(LOWER(:name), ' ', '') " +
+            "AND is_deleted = true LIMIT 1", nativeQuery = true)
+    Optional<Brand> findByNameIgnoreCaseAndIsDeletedTrue(@Param("name") String name);
+
+    @Query(value = "SELECT * FROM brands " +
+            "WHERE REPLACE(LOWER(name), ' ', '') = REPLACE(LOWER(:name), ' ', '') " +
+            "AND is_deleted = false LIMIT 1", nativeQuery = true)
+    Optional<Brand> findByNameIgnoreCaseAndIsDeletedFalse(@Param("name") String name);
 }

--- a/shopapp/shopapp/src/main/java/com/project/shopapp/repositories/CategoryRepository.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/repositories/CategoryRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     List<Category> findByIsDeletedFalse();
 
-    Optional<Category> findByIdAndIsDeletedFalse(Long id);
+    Optional<Category> findByIdAndIsDeletedFalse(Long categoryId);
 
     @Query(value = "SELECT * FROM categories " +
             "WHERE REPLACE(LOWER(name), ' ', '') = REPLACE(LOWER(:name), ' ', '') " +

--- a/shopapp/shopapp/src/main/java/com/project/shopapp/repositories/ProductRepository.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/repositories/ProductRepository.java
@@ -1,5 +1,6 @@
 package com.project.shopapp.repositories;
 
+import com.project.shopapp.models.Brand;
 import com.project.shopapp.models.Category;
 import com.project.shopapp.models.Order;
 import com.project.shopapp.models.Product;
@@ -19,6 +20,7 @@ public interface ProductRepository extends JpaRepository<Product,Long> {
     boolean existsByName (String name);
     Page<Product> findAllByIsDeletedFalse(Pageable pageable);
     List<Product> findByCategoryAndIsDeletedFalse(Category category);
+    List<Product> findByBrandAndIsDeletedFalse(Brand brand);
     @Query("SELECT p FROM Product p " +
             "WHERE p.isDeleted = false " +  // ✅ Lọc sản phẩm chưa bị xóa mềm
             "AND p.category.id = :categoryId " +

--- a/shopapp/shopapp/src/main/java/com/project/shopapp/services/admin/brand/BrandAdminService.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/services/admin/brand/BrandAdminService.java
@@ -1,0 +1,69 @@
+package com.project.shopapp.services.admin.brand;
+import com.project.shopapp.components.LocalizationUtils;
+import com.project.shopapp.dtos.customer.brand.BrandDto;
+import com.project.shopapp.exception.DataNotFoundException;
+import com.project.shopapp.models.Brand;
+import com.project.shopapp.models.Category;
+import com.project.shopapp.models.Product;
+import com.project.shopapp.repositories.BrandRepository;
+import com.project.shopapp.repositories.ProductRepository;
+import com.project.shopapp.ultis.MessageKeys;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class BrandAdminService implements IBrandAdminService {
+    @Autowired
+    private BrandRepository brandRepository;
+    @Autowired
+    private LocalizationUtils localizationUtils;
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Override
+    @Transactional
+    public Brand createBrand(BrandDto brandDto) throws Exception {
+        String name = brandDto.getName();
+        // Kiểm tra nếu thương hiệu đã tồn tại và chưa bị xóa mềm → báo lỗi
+        Optional<Brand> existingBrandOpt = brandRepository.findByNameIgnoreCaseAndIsDeletedFalse(name);
+        if (existingBrandOpt.isPresent()) {
+            throw new DataNotFoundException(
+                    localizationUtils.getLocalizedMessage(MessageKeys.CATEGORY_ALREADY_EXISTS, name)
+            );
+        }
+        // Nếu thương hiệu bị xóa mềm → khôi phục
+        Optional<Brand> deletedBrandOpt = brandRepository.findByNameIgnoreCaseAndIsDeletedTrue(name);
+        if (deletedBrandOpt.isPresent()) {
+            Brand deletedBrand = deletedBrandOpt.get();
+            deletedBrand.setDeleted(false);
+            return brandRepository.save(deletedBrand);
+        }
+        Brand newBrand = Brand.builder().
+                name(brandDto.getName()).
+                build();
+        return brandRepository.save(newBrand);
+    }
+    @Override
+    @Transactional
+    public void deleteBrandById(long brandId) throws Exception {
+        // Lấy category chưa bị xóa
+        Brand existingBrand = brandRepository.findByIdAndIsDeletedFalse( brandId)
+                .orElseThrow(() -> new DataNotFoundException(
+                        localizationUtils.getLocalizedMessage(MessageKeys.BRAND_NOT_FOUND,  brandId)
+                ));
+        // Xóa mềm danh mục
+        existingBrand.setDeleted(true);
+        brandRepository.save(existingBrand);
+        // Lấy toàn bộ sản phẩm thuộc danh mục chưa bị xóa mềm
+        List<Product> products = productRepository.findByBrandAndIsDeletedFalse(existingBrand);
+        // Xóa mềm toàn bộ sản phẩm thuộc danh mục này
+        for (Product product : products) {
+            product.setDeleted(true);
+        }
+        productRepository.saveAll(products);
+    }
+}

--- a/shopapp/shopapp/src/main/java/com/project/shopapp/services/admin/brand/IBrandAdminService.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/services/admin/brand/IBrandAdminService.java
@@ -1,0 +1,10 @@
+package com.project.shopapp.services.admin.brand;
+
+import com.project.shopapp.dtos.customer.brand.BrandDto;
+import com.project.shopapp.models.Brand;
+
+public interface IBrandAdminService {
+    Brand createBrand (BrandDto brandDto) throws Exception;
+
+    void deleteBrandById(long brandId) throws Exception;
+}

--- a/shopapp/shopapp/src/main/java/com/project/shopapp/services/admin/category/CategoryAdminService.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/services/admin/category/CategoryAdminService.java
@@ -24,6 +24,7 @@ public class CategoryAdminService  implements ICategoryAdminService{
     @Autowired
     private ProductRepository productRepository;
     @Override
+    @Transactional
     public Category createCategory(CategoryDto categoryDto) throws Exception {
         String name = categoryDto.getName();
         // Kiểm tra nếu danh mục đã tồn tại và chưa bị xóa mềm → báo lỗi
@@ -51,7 +52,7 @@ public class CategoryAdminService  implements ICategoryAdminService{
     public void deleteCategoryById(long id) throws Exception {
         // Lấy category chưa bị xóa
         Category existingCategory = categoryRepository.findByIdAndIsDeletedFalse(id)
-                .orElseThrow(() -> new RuntimeException(
+                .orElseThrow(() -> new DataNotFoundException(
                         localizationUtils.getLocalizedMessage(MessageKeys.CATEGORY_NOT_FOUND, id)
                 ));
         // Xóa mềm danh mục

--- a/shopapp/shopapp/src/main/java/com/project/shopapp/services/customer/brand/BrandService.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/services/customer/brand/BrandService.java
@@ -19,14 +19,6 @@ public class BrandService implements IBrandService {
     private final LocalizationUtils localizationUtils;
     private final CategoryRepository categoryRepository;
     @Override
-    public Brand createBrand(BrandDto brandDto) {
-        Brand newBrand = Brand.builder().
-                name(brandDto.getName()).
-                build();
-        return brandRepository.save(newBrand);
-    }
-
-    @Override
     public List<Brand> getBrandsByCategory(Long categoryId) throws Exception {
         boolean exists = categoryRepository.existsById(categoryId);
         if (!exists) {
@@ -38,6 +30,6 @@ public class BrandService implements IBrandService {
 
     @Override
     public List<Brand> getAllBrands() {
-        return brandRepository.findAll();
+        return brandRepository.findByIsDeletedFalse();
     }
 }

--- a/shopapp/shopapp/src/main/java/com/project/shopapp/services/customer/brand/IBrandService.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/services/customer/brand/IBrandService.java
@@ -6,8 +6,6 @@ import com.project.shopapp.models.Brand;
 import java.util.List;
 
 public interface IBrandService {
-    Brand createBrand (BrandDto brandDto);
-
     List<Brand> getBrandsByCategory (Long categoryId) throws Exception;
 
     List<Brand> getAllBrands();

--- a/shopapp/shopapp/src/main/java/com/project/shopapp/ultis/MessageKeys.java
+++ b/shopapp/shopapp/src/main/java/com/project/shopapp/ultis/MessageKeys.java
@@ -96,7 +96,7 @@ public class MessageKeys {
     public static final String BRAND_FETCHED_BY_CATEGORY_SUCCESSFULLY = "brand.fetched_by_category_successfully";
     public static final String BRAND_NOT_FOUND = "brand.not_found";
     public static final String BRAND_GET_LIST_BRANDS_SUCCESSFULLY = "brand.get-list-brands-successfully";
-
+    public static final String BRAND_DELETE_SUCCESSFULLY = "brand.delete_successfully";
     public static final String VALUE_MIN_MAX_SUCCESSFULLY = "value.min.max.successfully";
 
     public static final String CREATED_ACCESS_TOKEN_SUCCESSFULLY = "access_token.created_successfully";

--- a/shopapp/shopapp/src/main/resources/i18n/messages_en.properties
+++ b/shopapp/shopapp/src/main/resources/i18n/messages_en.properties
@@ -13,7 +13,7 @@ user.update_profile_successfully = Profile information has been updated successf
 user.account_locked=Your account has been locked. Please contact the administrator.
 
 category.created.successfully = Created category {0} successfully
-category.delete_successfully=Delete category with id: {0} successfully
+category.delete_successfully= Delete category with id: {0} successfully
 category.get_list_categories_successfully = Get list of categories successfully
 category.get_category_successfully = Get category information successfully
 category.not_found = Category not found with id: {0}
@@ -87,6 +87,7 @@ brand.create_successfully = Created brand with id: {0} successfully
 brand.fetched_by_category_successfully = Successfully fetched brands for category with id: {0}
 brand.not_found = Cannot find brand with id:{0}
 brand.get-list-brands-successfully = Successfully retrieved list of brands
+brand.delete_successfully = Delete brand with id: {0} successfully
 
 access_token.created_successfully = Create Access Token successfully
 refresh_token.not.found=Cannot find Refresh Token.

--- a/shopapp/shopapp/src/main/resources/i18n/messages_vi.properties
+++ b/shopapp/shopapp/src/main/resources/i18n/messages_vi.properties
@@ -13,11 +13,9 @@ user.not_found = Không tìm thấy người dùng
 user.found_successfully = Tìm thấy người dùng thành công
 user.account_locked = Tài khoản của bạn đã bị khóa . Vui lòng liên hệ quản trị viên
 
-category.update_category.update_successfully= Cập nhật danh mục thành công
 category.get_list_categories_successfully = Lấy danh sách các danh mục thành công
 category.get_category_successfully = Lấy thông tin danh mục thành công
 category.not_found = Không tìm thấy danh mục có id: {0}
-category.cannot_delete_category_product = Không thể xóa danh mục có sản phẩm liên quan
 category.delete_successfully = Xóa danh mục có id: {0} thành công
 category.created.successfully = Tạo danh mục {0} thành công
 
@@ -90,6 +88,7 @@ brand.create_successfully = Tạo thương hiệu với id: {0} thành công
 brand.fetched_by_category_successfully = Lấy thương hiệu theo danh mục có id: {0} thành công
 brand.not_found = Không tìm thấy thương hiệu với id:{0}
 brand.get-list-brands-successfully = Lấy danh sách thương hiệu thành công
+brand.delete_successfully = Xóa thương hiệu có id: {0} thành công
 
 access_token.created_successfully = Tạo mới AccessToken thành công
 refresh_token.not.found = Không tìm thấy Refresh Token 

--- a/shopapp/shopapp_admin/shopapp_admin/src/app/app.routes.ts
+++ b/shopapp/shopapp_admin/shopapp_admin/src/app/app.routes.ts
@@ -9,6 +9,7 @@ import { CustomerComponent } from './components/customer/customer.component';
 import { OrderComponent } from './components/order/order.component';
 import { ProductComponent } from './components/product/product.component';
 import { CategoryComponent } from './components/category/category.component';
+import { BrandComponent } from './components/brand/brand.component';
 
 export const routes: Routes = [
   // 👉 Redirect từ path rỗng sang signin
@@ -38,7 +39,7 @@ export const routes: Routes = [
       { path: 'order', component: OrderComponent },
       { path: 'product', component: ProductComponent },
       { path: 'category', component: CategoryComponent },
-
+      { path: 'brand', component: BrandComponent },
       // Có thể thêm các route khác như: profile, dashboard, ...
     ]
   },

--- a/shopapp/shopapp_admin/shopapp_admin/src/app/components/add-brand/add-brand.component.html
+++ b/shopapp/shopapp_admin/shopapp_admin/src/app/components/add-brand/add-brand.component.html
@@ -1,0 +1,20 @@
+<ng-template #content let-c="close" let-d="dismiss">
+    <div class="modal-header">
+        <h2 class="modal-title m-0">Thêm thương hiệu sản phẩm</h2>
+    </div>
+    <form [formGroup]="brandForm" (ngSubmit)="submitBrand()">
+        <div class="form-group">
+            <label for="name">Tên thương hiệu</label>
+            <input id="name" type="text" formControlName="name" class="form-control">
+            <p class="text-danger" *ngIf="brandForm.get('name')?.touched && brandForm.get('name')?.invalid">
+                Tên thương hiệu là bắt buộc
+            </p>
+        </div>
+
+        <button type="submit" [disabled]="brandForm.invalid" class="btn btn-primary">Thêm</button>
+    </form>
+</ng-template>
+<button mat-raised-button color="primary" (click)="open(content)">
+    <mat-icon class="mr-1">add</mat-icon>
+    <span class="button-text">Thêm thương hiệu sản phẩm</span>
+</button>

--- a/shopapp/shopapp_admin/shopapp_admin/src/app/components/add-brand/add-brand.component.scss
+++ b/shopapp/shopapp_admin/shopapp_admin/src/app/components/add-brand/add-brand.component.scss
@@ -1,0 +1,133 @@
+
+/* --- Modal Container --- */
+.modal-header {
+  background-color: #3f51b5;
+  color: white;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #dee2e6;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  user-select: none;
+}
+
+.modal-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.modal-body {
+  background-color: #f8f9fa;
+  border-radius: 0 0 6px 6px;
+  padding: 1.5rem;
+}
+
+/* --- Form --- */
+form {
+  padding: 0.5rem 0;
+  user-select: none;
+}
+
+.form-group {
+  margin-bottom: 1.2rem;
+  position: relative;
+}
+
+label {
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+  display: block;
+}
+
+input.form-control,
+select.form-control {
+  border: 1px solid #ced4da;
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.95rem;
+  width: 100%;
+  transition: all 0.2s ease-in-out;
+
+  &:focus {
+    border-color: #3f51b5;
+    box-shadow: 0 0 0 0.15rem rgba(63, 81, 181, 0.25);
+  }
+}
+
+input.ng-invalid.ng-touched,
+select.ng-invalid.ng-touched {
+  border-color: #dc3545;
+}
+
+/* --- Error Text --- */
+.text-danger {
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}
+
+/* --- Password Toggle Icon --- */
+.password-toggle {
+  position: absolute;
+  right: 12px;
+  top: 45px;
+  z-index: 2;
+  color: #6c757d;
+  cursor: pointer;
+
+  &:hover {
+    color: #3f51b5;
+  }
+}
+
+// Trong add-customer.component.scss
+button[mat-raised-button] {
+  font-weight: 600;
+  text-transform: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start; // ✅ Cho phép icon và text tự căn lề trái
+  gap: 6px;
+  padding: 10px 18px;
+  font-size: 15px;
+  line-height: 1.2;
+  border-radius: 8px;
+  margin-top: -40px;
+  box-shadow: 0 2px 6px rgba(0, 123, 255, 0.3);
+  background-color: #007bff;
+  color: white;
+  border: none;
+
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+
+  &:hover {
+    background-color: #0056b3;
+    box-shadow: 0 4px 10px rgba(0, 91, 187, 0.4);
+  }
+
+  mat-icon {
+    font-size: 20px;
+    line-height: 1;
+    vertical-align: middle;
+    transform: translate(-4px, 1.5px); // 👈 Dịch nhẹ icon thôi
+  }
+
+  .button-text {
+    position: relative;
+    left: -6px; // ✅ Giờ mới có tác dụng
+  }
+  
+}
+::ng-deep .custom-modal-md .modal-dialog {
+  max-width: 500px; /* Bạn có thể giảm nữa nếu muốn */
+  width: 90%;
+}
+
+::ng-deep .custom-modal-md .modal-content {
+  padding: 20px;
+  border-radius: 10px;
+}
+.disabled-button {
+  opacity: 0.6;
+  pointer-events: none;
+  cursor: not-allowed;
+}

--- a/shopapp/shopapp_admin/shopapp_admin/src/app/components/add-brand/add-brand.component.ts
+++ b/shopapp/shopapp_admin/shopapp_admin/src/app/components/add-brand/add-brand.component.ts
@@ -1,0 +1,71 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Output } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatIcon } from '@angular/material/icon';
+import { BrandService } from '../../services/brand.service';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { ToastrService } from 'ngx-toastr';
+import { CreateBrandDto } from '../../dtos/create.brand.dto';
+import Swal from 'sweetalert2';
+
+@Component({
+  selector: 'app-add-brand',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MatIcon],
+  templateUrl: './add-brand.component.html',
+  styleUrl: './add-brand.component.scss'
+})
+export class AddBrandComponent {
+  @Output() brandAdded = new EventEmitter<void>();
+  brandForm: FormGroup;
+  constructor(private fb: FormBuilder,
+    private brandService: BrandService,
+    private modalService: NgbModal,
+    private toastr: ToastrService) {
+    this.brandForm = this.fb.group({
+      name: ['', Validators.required]
+    });
+  }
+  open(content: any) {
+    this.brandForm.reset(); // Reset lại form về trạng thái ban đầu
+    this.modalService.open(content, {
+      centered: true,
+      windowClass: 'custom-modal-md'
+    });
+  }
+  // Hàm thêm thương hiệu mới
+  submitBrand() {
+    if (this.brandForm.invalid) {
+      this.toastr.error('Vui lòng nhập đầy đủ thông tin.', 'Lỗi', {
+        timeOut: 1500,
+        progressBar: true,
+      });
+      return;
+    }
+    const brandDto: CreateBrandDto = {
+      name: this.brandForm.value.name
+    };
+    this.brandService.createNewBrand(brandDto).subscribe({
+      next: () => {
+        Swal.fire({
+          icon: 'success',
+          title: 'Thêm thương hiệu thành công',
+          showConfirmButton: false,
+          timer: 1500,
+          customClass: { popup: 'custom-swal' },
+        }).then(() => {
+          this.brandAdded.emit(); // emit để reload bảng
+          this.modalService.dismissAll(); // đóng modal
+          this.brandForm.reset(); // reset lại form
+        });
+      },
+      error: (error) => {
+        const errorMessage = error.error.message || 'Đã xảy ra lỗi';
+        this.toastr.error(errorMessage, 'Lỗi', {
+          timeOut: 1500,
+          progressBar: true,
+        });
+      },
+    });
+  }
+}

--- a/shopapp/shopapp_admin/shopapp_admin/src/app/components/brand/brand.component.html
+++ b/shopapp/shopapp_admin/shopapp_admin/src/app/components/brand/brand.component.html
@@ -1,0 +1,59 @@
+<div class="container-fluid brand-table-container">
+    <!-- Tiêu đề -->
+    <div class="d-sm-flex align-items-center justify-content-between mb-4">
+        <h1 class="h3 mb-0 text-gray-800 title-shift-up">📦 Thương hiệu sản phẩm</h1>
+        <div class="d-flex justify-content-end mb-3 add-brand-wrapper">
+            <app-add-brand (brandAdded)="onBrandAdded()"></app-add-brand>
+        </div>
+    </div>
+
+    <!-- Tìm kiếm -->
+    <div class="search-wrapper mb-3">
+        <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Tìm kiếm thương hiệu</mat-label>
+            <input matInput [(ngModel)]="keyword" placeholder="Nhập tên thương hiệu..." (keyup)="applyFilter()">
+            <button mat-icon-button matSuffix disabled>
+                <mat-icon>search</mat-icon>
+            </button>
+        </mat-form-field>
+    </div>
+
+    <!-- Bảng dữ liệu -->
+    <div class="table-wrapper">
+        <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8 custom-table">
+            <!-- ID -->
+            <ng-container matColumnDef="id">
+                <th mat-header-cell *matHeaderCellDef mat-sort-header>ID</th>
+                <td mat-cell *matCellDef="let row">{{ row.id }}</td>
+            </ng-container>
+
+            <!-- Tên thương hiệu -->
+            <ng-container matColumnDef="name">
+                <th mat-header-cell *matHeaderCellDef mat-sort-header>Tên thương hiệu</th>
+                <td mat-cell *matCellDef="let row">{{ row.name }}</td>
+            </ng-container>
+
+            <!-- Hành động -->
+            <ng-container matColumnDef="actions">
+                <th mat-header-cell *matHeaderCellDef>Hành động</th>
+                <td mat-cell *matCellDef="let row">
+                    <!-- Nút xóa -->
+                    <button mat-icon-button matTooltip="Xóa danh mục" (click)="confirmDelete(row)" class="ml-2">
+                        <mat-icon style="color: #f44336;">delete</mat-icon>
+                    </button>
+                </td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+        </table>
+
+        <!-- Phân trang -->
+        <mat-paginator [pageSize]="5" [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
+    </div>
+
+    <!-- Thông báo không tìm thấy -->
+    <div *ngIf="dataSource.data.length === 0" class="no-records-message">
+        ❌ Không tìm thấy thương hiệu nào phù hợp với từ khóa "{{ keyword }}"
+    </div>
+</div>

--- a/shopapp/shopapp_admin/shopapp_admin/src/app/components/brand/brand.component.scss
+++ b/shopapp/shopapp_admin/shopapp_admin/src/app/components/brand/brand.component.scss
@@ -1,0 +1,79 @@
+.title-shift-up {
+  font-size: 28px;
+  font-weight: 700;
+  color: #343a40;
+  margin-top: 60px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+* {
+  text-decoration: none !important;
+  caret-color: transparent;
+}
+
+.brand-table-container {
+  padding: 20px;
+
+  .search-wrapper {
+    mat-form-field {
+      background: #fff;
+      border-radius: 6px;
+
+      input {
+        padding-left: 8px;
+      }
+
+      mat-icon {
+        color: #888;
+      }
+    }
+  }
+
+  .table-wrapper {
+    overflow-x: auto;
+
+    table.custom-table {
+      width: 100%;
+      border-spacing: 0;
+      border-collapse: collapse;
+
+      th {
+        background-color: #f8f9fc;
+        color: #4e73df;
+        font-weight: 600;
+        border-bottom: 2px solid #e3e6f0;
+        text-align: left;
+      }
+
+      td {
+        vertical-align: middle;
+        border-bottom: 1px solid #dee2e6;
+        transition: background-color 0.2s;
+      }
+
+      tr:hover td {
+        background-color: #f1f5ff;
+      }
+    }
+  }
+}
+
+::ng-deep td.mat-column-actions {
+  white-space: nowrap;
+  transform: translateX(-10px);
+}
+
+.no-records-message {
+  text-align: center;
+  margin: 20px 0;
+  font-size: 16px;
+  color: #888;
+}
+.add-brand-wrapper{
+    margin-top: 90px;
+}
+.ml-2 {
+  margin-left: 20px;
+}

--- a/shopapp/shopapp_admin/shopapp_admin/src/app/components/brand/brand.component.ts
+++ b/shopapp/shopapp_admin/shopapp_admin/src/app/components/brand/brand.component.ts
@@ -1,0 +1,110 @@
+import { CommonModule } from '@angular/common';
+import { Component, ViewChild } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { BrandService } from '../../services/brand.service';
+import { Brand } from '../../models/brand.model';
+import Swal from 'sweetalert2';
+import { AddBrandComponent } from '../add-brand/add-brand.component';
+
+
+@Component({
+  selector: 'app-brand',
+  standalone: true,
+  imports: [CommonModule, FormsModule,
+      MatTableModule,
+      MatPaginatorModule,
+      MatSortModule,
+      MatFormFieldModule,
+      MatInputModule,
+      MatIconModule,
+      MatButtonModule,
+      MatTooltipModule,
+      AddBrandComponent
+      ],
+  templateUrl: './brand.component.html',
+  styleUrl: './brand.component.scss'
+})
+export class BrandComponent {
+    totalItems: number = 0;
+    keyword: string = '';
+    displayedColumns: string[] = ['id', 'name', 'actions'];
+    dataSource = new MatTableDataSource<any>();
+  
+    // 👇 Dùng ViewChild để lấy đối tượng MatPaginator từ template
+    @ViewChild(MatPaginator) paginator!: MatPaginator;
+    @ViewChild(MatSort) sort!: MatSort;
+    constructor(
+      private brandService: BrandService,
+    ) { }
+    ngOnInit() {
+      this.getAllBrands();
+    }
+    ngAfterViewInit() {
+      this.dataSource.sort = this.sort;
+    }
+    //Hàm lấy danh sách danh mục
+    getAllBrands() {
+      this.brandService.getAllBrands().subscribe({
+        next: (res) => {
+          this.dataSource.data = res.data;
+          this.dataSource.paginator = this.paginator;
+          //Định nghĩa cách lọc
+          this.dataSource.filterPredicate = (data: Brand, filter: string) => {
+            const keyword = filter;
+            return data.name.toLowerCase().includes(keyword) || data.id.toString().includes(keyword);
+          };
+        },
+        error: (err) => {
+          console.error('❌ Lỗi:', err?.error?.message || 'Lỗi khi tải danh mục');
+        }
+      });
+    }
+    //Hàm load lại danh sách danh mục
+    onBrandAdded() {
+      // Reload lại danh sách danh mục sản phẩm
+      this.getAllBrands();
+    }
+    applyFilter() {
+      this.dataSource.filter = this.keyword.trim().toLowerCase();
+    }
+    //Hàm xóa mềm danh mục
+    confirmDelete(brand: Brand): void {
+      Swal.fire({
+        title: 'Xác nhận xóa',
+        text: `Bạn có chắc chắn muốn xóa danh mục "${brand.name}" không?`,
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: '#d33',
+        cancelButtonColor: '#3085d6',
+        confirmButtonText: 'Xóa',
+        cancelButtonText: 'Hủy'
+      }).then((result) => {
+        if (result.isConfirmed) {
+          this.brandService.deleteBrandById(brand.id).subscribe({
+            next: () => {
+              Swal.fire({
+                title: 'Đã xóa!',
+                text: `Thương hiệu "${brand.name}" đã được xóa thành công.`,
+                icon: 'success',
+                timer: 2000,
+                showConfirmButton: false
+              });
+              this.getAllBrands(); // Load lại danh sách
+            },
+            error: (err) => {
+              console.error('❌ Lỗi:', err?.error?.message || 'Lỗi không xác định');
+            }
+          });
+        }
+      });
+    }
+
+}

--- a/shopapp/shopapp_admin/shopapp_admin/src/app/components/category/category.component.ts
+++ b/shopapp/shopapp_admin/shopapp_admin/src/app/components/category/category.component.ts
@@ -90,7 +90,7 @@ export class CategoryComponent {
           next: () => {
             Swal.fire({
               title: 'Đã xóa!',
-              text: `Sản phẩm "${category.name}" đã được xóa thành công.`,
+              text: `Danh mục "${category.name}" đã được xóa thành công.`,
               icon: 'success',
               timer: 2000,
               showConfirmButton: false

--- a/shopapp/shopapp_admin/shopapp_admin/src/app/components/sidebar/sidebar.component.html
+++ b/shopapp/shopapp_admin/shopapp_admin/src/app/components/sidebar/sidebar.component.html
@@ -49,7 +49,7 @@
     </a>
   </li>
   <li class="nav-item" routerLinkActive="active">
-    <a class="nav-link" routerLink="/admin/category">
+    <a class="nav-link" routerLink="/admin/brand">
       <i class="fas fa-table fa-chart-area"></i>
       <span>Thương hiệu sản phẩm</span>
     </a>

--- a/shopapp/shopapp_admin/shopapp_admin/src/app/dtos/create.brand.dto.ts
+++ b/shopapp/shopapp_admin/shopapp_admin/src/app/dtos/create.brand.dto.ts
@@ -1,0 +1,3 @@
+export interface CreateBrandDto {
+  name: string;
+}

--- a/shopapp/shopapp_admin/shopapp_admin/src/app/services/brand.service.ts
+++ b/shopapp/shopapp_admin/shopapp_admin/src/app/services/brand.service.ts
@@ -4,16 +4,27 @@ import { Injectable } from '@angular/core';
 import { Brand } from '../models/brand.model';
 import { environment } from '../environments/environment';
 import { Observable } from 'rxjs';
+import { CreateBrandDto } from '../dtos/create.brand.dto';
 
 @Injectable({
   providedIn: 'root'
 })
 export class BrandService {
   private apigetAllBrands = `${environment.apiBaseUrl}/brands/get-all`;
+  private apiDeleteBrand = `${environment.apiBaseAdminUrl}/brands/delete`;
+  private apiCreateNewBrand = `${environment.apiBaseAdminUrl}/brands/create`;
   constructor(private http: HttpClient) { }
 
   //Api lấy danh sách thương hiệu sản phẩm
   getAllBrands(): Observable<ApiResponse<Brand[]>> {
     return this.http.get<ApiResponse<Brand[]>>(this.apigetAllBrands);
+  }
+  //Api tạo mới thương hiệu sản phẩm
+  createNewBrand(createBrandDto: CreateBrandDto): Observable<ApiResponse<Brand>> {
+    return this.http.post<ApiResponse<Brand>>(this.apiCreateNewBrand, createBrandDto)
+  }
+  //Api xóa mềm thương hiệu
+  deleteBrandById(brandId: number): Observable<ApiResponse<any>> {
+    return this.http.delete<ApiResponse<any>>(`${this.apiDeleteBrand}/${brandId}`);
   }
 }


### PR DESCRIPTION
## 📌 Purpose
Implement the logic to create new brands and soft-delete existing ones. When a brand is soft-deleted, all related products are also soft-deleted to maintain data consistency.

---

## ✅ Changes Made
- Added API to create a new brand (`POST /brands`)
- Validate unique brand name (case-insensitive)
- Restore brand if a soft-deleted one with the same name already exists
- Added API to soft-delete a brand (`DELETE /brands/{id}`)
- Automatically soft-delete all products associated with the brand
- Used `@Transactional` to ensure all operations are atomic

---

## 🔍 How to Test
1. Create a new brand → should be created successfully.
2. Create the same brand again → should return an error.
3. Delete the brand → brand and all its related products should be marked as deleted (`is_deleted = true`).
4. Create a brand with the same name again → should restore the previously deleted brand.